### PR TITLE
add Zobrist hashing for chess positions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,14 @@ dependencies = [
  "raw",
  "types",
  "utilities",
+ "zobrist",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "engine"
@@ -27,10 +34,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "raw"
 version = "0.1.0"
 dependencies = [
  "utilities",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.110"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -47,5 +139,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
 name = "utilities"
 version = "0.1.0"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zobrist"
+version = "0.1.0"
+dependencies = [
+ "rand",
+ "rand_chacha",
+ "types",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = [ "crates/board", "crates/engine", "crates/evaluation", "crates/raw", "crates/types", "crates/uci", "crates/utilities"]
+members = [ "crates/board", "crates/engine", "crates/evaluation", "crates/raw", "crates/types", "crates/uci", "crates/utilities", "crates/zobrist"]
 
 [profile.release]
 opt-level = 3        # max LLVM optimizations

--- a/crates/board/Cargo.toml
+++ b/crates/board/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2024"
 
 [dependencies]
 types = {path = "../types/"}
+zobrist = {path = "../zobrist/"}
 utilities = { path = "../utilities/" }
 raw = {path = "../raw/"}

--- a/crates/board/src/fen.rs
+++ b/crates/board/src/fen.rs
@@ -45,6 +45,8 @@ impl Position {
         // Parse fullmove number (part 5)
         position.full_clock = parts[5].parse().map_err(|_| "Invalid fullmove number")?;
 
+        position.hash = position.compute_hash();
+
         Ok(position)
     }
 
@@ -120,7 +122,7 @@ impl Position {
         Ok((piece, color))
     }
 
-    /// Parses the side to move from the provided string 
+    /// Parses the side to move from the provided string
     fn parse_side_to_move(side_str: &str) -> Result<Color, String> {
         match side_str {
             "w" => Ok(Color::White),

--- a/crates/board/src/zobrist/mod.rs
+++ b/crates/board/src/zobrist/mod.rs
@@ -1,0 +1,51 @@
+use types::others::{Color, Piece};
+use zobrist::ZOBRIST;
+
+use crate::Position;
+
+impl Position {
+    pub fn compute_hash(&self) -> u64 {
+        let mut hash = 0u64;
+
+        // Hash all pieces on the board
+        for square in 0..64 {
+            if let Some((piece, color)) = self.piece_map[square] {
+                hash ^= ZOBRIST.piece(piece, color, square);
+            }
+        }
+
+        // Hash castling rights
+        hash ^= ZOBRIST.castling_key(self.castling_rights);
+
+        // Hash en passant
+        if let Some(ep_square) = self.en_passant {
+            let file = (ep_square % 8) as usize;
+            hash ^= ZOBRIST.en_passant_key(file);
+        }
+
+        // Hash side to move (only XOR if black)
+        if self.side_to_move == Color::Black {
+            hash ^= ZOBRIST.side_to_move;
+        }
+
+        hash
+    }
+
+    /// Remove piece WITHOUT updating hash (for unmake_move)
+    #[inline(always)]
+    pub fn remove_piece_silent(&mut self, idx: usize) {
+        if let Some((piece, _color)) = self.piece_map[idx] {
+            self.pieces[piece as usize].remove_bit(idx);
+            self.all_pieces[_color as usize].remove_bit(idx);
+            self.piece_map[idx] = None;
+        }
+    }
+
+    /// Add piece WITHOUT updating hash (for unmake_move)
+    #[inline(always)]
+    pub fn add_piece_silent(&mut self, idx: usize, color: Color, piece: Piece) {
+        self.pieces[piece as usize].set_bit(idx);
+        self.all_pieces[color as usize].set_bit(idx);
+        self.piece_map[idx] = Some((piece, color));
+    }
+}

--- a/crates/zobrist/Cargo.toml
+++ b/crates/zobrist/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "zobrist"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+types = { path = "../types" }
+rand = "0.8"
+rand_chacha = "0.3"

--- a/crates/zobrist/src/lib.rs
+++ b/crates/zobrist/src/lib.rs
@@ -1,0 +1,2 @@
+mod zobrist_nums;
+pub use zobrist_nums::ZOBRIST;

--- a/crates/zobrist/src/zobrist_nums.rs
+++ b/crates/zobrist/src/zobrist_nums.rs
@@ -1,0 +1,90 @@
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::sync::LazyLock;
+use types::others::{CastleRights, Color, Piece};
+
+pub struct ZobristTables {
+    pub pieces: [[u64; 64]; 12],
+    pub castling: [u64; 4],
+    pub en_passant: [u64; 8],
+    pub side_to_move: u64,
+}
+
+impl ZobristTables {
+    pub fn generate() -> Self {
+        let mut rng = ChaCha8Rng::seed_from_u64(0x5EED_C0DE_CAFE_BABE);
+        
+        // Generate Piece Square Tables
+        let mut pieces = [[0u64; 64]; 12];
+        for piece in 0..12 {
+            for square in 0..64 {
+                pieces[piece][square] = rng.r#gen();
+            } }
+        
+        // Generate Castling Rights
+        let mut castling_rights = [0u64; 4];
+        for i in 0..4 {
+            castling_rights[i] = rng.r#gen();
+        }
+        
+        // Generate En-Passant files
+        let mut enpassant_files = [0u64; 8];
+        for i in 0..8 {
+            enpassant_files[i] = rng.r#gen();
+        }
+        
+        Self {
+            pieces,
+            castling: castling_rights,
+            en_passant: enpassant_files,
+            side_to_move: rng.r#gen(),
+        }
+    }
+    
+    /// Get the Zobrist for a piece on a square
+    #[inline(always)]
+    pub fn piece(&self, piece: Piece, color: Color, square: usize) -> u64 {
+        let piece_idx = Self::piece_index(piece, color);
+        self.pieces[piece_idx][square]
+    }
+    
+    /// Convert Piece + Color to table index
+    #[inline(always)]
+    fn piece_index(piece: Piece, color: Color) -> usize {
+        let base = piece as usize;
+        match color {
+            Color::White => base,
+            Color::Black => base + 6,
+        }
+    }
+    
+    /// Get Zobrist key for castling rights
+    #[inline(always)]
+    pub fn castling_key(&self, rights: CastleRights) -> u64 {
+        let mut key = 0u64;
+        
+        if rights.0 & CastleRights::WHITE_KING.0 != 0 {
+            key ^= self.castling[0];
+        }
+        if rights.0 & CastleRights::WHITE_QUEEN.0 != 0 {
+            key ^= self.castling[1];
+        }
+        if rights.0 & CastleRights::BLACK_KING.0 != 0 {
+            key ^= self.castling[2];
+        }
+        if rights.0 & CastleRights::BLACK_QUEEN.0 != 0 {
+            key ^= self.castling[3];
+        }
+        
+        key
+    }
+    
+    #[inline(always)]
+    pub fn en_passant_key(&self, file: usize) -> u64 {
+        self.en_passant[file]
+    }
+}
+
+pub static ZOBRIST: LazyLock<ZobristTables> = LazyLock::new(|| {
+    ZobristTables::generate()
+});


### PR DESCRIPTION
Implements incremental hash computation with XOR operations for:
- Piece placement (12 piece types * 64 squares)
- Castling rights (4 flags)
- En passant file (8 files)
- Side to move

Base for Transposition Tables